### PR TITLE
Add new weekly event pages and reorganise events collection

### DIFF
--- a/events/thursdays-at-the-den.md
+++ b/events/thursdays-at-the-den.md
@@ -1,0 +1,38 @@
+---
+title: "Thursdays at The Den"
+subtitle: "Weekly Sing & Strum Session"
+recurring_date: "Thursdays - 5:30pm-7pm"
+event_location: "The Den, Stubbins Vale Rd., Ramsbottom"
+header_text: "Thursdays at The Den"
+meta_title: "Thursday Sessions | The Den | Uke Group North"
+meta_description: "Join our weekly Sing & Strum session at The Den every Thursday 5:30pm-7pm. £6 per person. Perfect for after work or school."
+---
+
+## Weekly Sing & Strum Session
+
+Join us every Thursday evening at The Den for our popular Sing & Strum session. This early evening session is perfect for those who can't make daytime sessions - great for after work or school!
+
+### Session Details
+
+- **When:** Every Thursday, 5:30pm - 7:00pm
+- **Where:** The Den, Stubbins Vale Rd., Ramsbottom
+- **Cost:** £6 per person
+- **Instrument hire:** +£2 if required
+
+### What to Expect
+
+Our Thursday evening sessions have a relaxed atmosphere in the comfortable setting of The Den. We play and sing a variety of songs together, suitable for all abilities. It's a great way to unwind after your day while learning and having fun with music.
+
+### What to Bring
+
+- Your ukulele (or hire one of ours for £2)
+- A music stand if you have one
+- Your enthusiasm!
+
+### Booking
+
+- Email: [ukegroupnorth@gmail.com](mailto:ukegroupnorth@gmail.com)
+- Spaces are limited to ensure quality instruction
+- Block booking discounts available
+
+All abilities welcome - whether you're coming straight from work or school, or just prefer evening sessions, we'd love to see you there!

--- a/events/tuesdays-at-ramsbottom-library.md
+++ b/events/tuesdays-at-ramsbottom-library.md
@@ -1,0 +1,38 @@
+---
+title: "Tuesdays at Ramsbottom Library"
+subtitle: "Weekly Sing & Strum Session"
+recurring_date: "Tuesdays - 10:30am-12pm"
+event_location: "Ramsbottom Library, Carr St., Ramsbottom"
+header_text: "Tuesdays at Ramsbottom Library"
+meta_title: "Tuesday Sessions | Ramsbottom Library | Uke Group North"
+meta_description: "Join our weekly Sing & Strum session at Ramsbottom Library every Tuesday 10:30am-12pm. £8 per person. All abilities welcome."
+---
+
+## Weekly Sing & Strum Session
+
+Join us every Tuesday morning at Ramsbottom Library for our popular Sing & Strum session. This is our most established regular session, perfect for putting your skills into practice while having fun with a friendly group.
+
+### Session Details
+
+- **When:** Every Tuesday, 10:30am - 12:00pm
+- **Where:** Ramsbottom Library, Carr St., Ramsbottom
+- **Cost:** £8 per person
+- **Instrument hire:** +£2 if required
+
+### What to Expect
+
+Our Tuesday morning sessions are relaxed and welcoming. We play a variety of songs together, from classics to contemporary hits, all arranged for ukulele. The session is suitable for mixed abilities - whether you're a confident player or still building your skills, you'll find a warm welcome here.
+
+### What to Bring
+
+- Your ukulele (or hire one of ours for £2)
+- A music stand if you have one
+- Your enthusiasm!
+
+### Booking
+
+- Email: [ukegroupnorth@gmail.com](mailto:ukegroupnorth@gmail.com)
+- Spaces are limited to ensure quality instruction
+- Block booking discounts available
+
+All abilities welcome - don't be shy, come and join us!

--- a/pages/events.md
+++ b/pages/events.md
@@ -1,0 +1,23 @@
+---
+header_text: "Events"
+meta_title: "Events | Uke Group North"
+meta_description: "Regular ukulele sessions and special events in Ramsbottom and surrounding areas."
+subtitle: "Join us for regular sessions and special events"
+header_image: /images/nsplsh_e2c54881820b44f7a1eadf4c7e33041a_mv2.jpg
+eleventyNavigation:
+  key: Events
+  order: 3
+permalink: /events/
+---
+
+## Regular Sessions
+
+We run regular weekly Sing & Strum sessions in Ramsbottom. These are friendly, inclusive gatherings where we play and sing together. All abilities welcome!
+
+### Our Weekly Sessions
+
+Join us at one of our regular sessions - perfect for putting your skills into practice while having fun with a friendly group.
+
+---
+
+*Check individual event pages for full details and booking information.*

--- a/pages/workshops.md
+++ b/pages/workshops.md
@@ -16,21 +16,7 @@ We offer a comprehensive range of workshops designed to meet you wherever you ar
 
 ## Regular Weekly Sessions
 
-### Sing & Strum Sessions
-
-Our most popular offering! These weekly sessions are perfect for putting your skills into practice while having fun with a friendly group.
-
-**Ramsbottom Library**
-- Tuesdays 10:30am - 12:00pm
-- £8 per person
-- Mixed ability welcome
-- Ukuleles available to borrow
-
-**The Den**
-- Tuesdays 5:30pm - 7:00pm  
-- £6 per person
-- Great for after work/school
-- Relaxed atmosphere
+Our popular Sing & Strum sessions run throughout the week at various locations. Please visit our [Events page](/events/) for full details of all regular sessions and special events.
 
 ## Beginner Workshops
 


### PR DESCRIPTION
## Summary
- Added new event pages for "Thursdays at The Den" and "Tuesdays at Ramsbottom Library" weekly Sing & Strum sessions
- Created a new main Events page summarising regular sessions with links to individual event details
- Updated Workshops page to reference the new Events page for session details instead of listing them directly

## Changes

### Events
- **thursdays-at-the-den.md**: New event page for Thursday evening sessions at The Den, including session details, booking info, and costs
- **tuesdays-at-ramsbottom-library.md**: New event page for Tuesday morning sessions at Ramsbottom Library with full session info and booking details
- **events.md**: New main Events page providing an overview of regular weekly sessions and directing users to individual event pages

### Workshops
- Removed detailed Sing & Strum session listings from Workshops page
- Added a reference link to the new Events page for full details on regular sessions and special events

## Test plan
- [x] Verify new event pages render correctly with all session details
- [x] Confirm Events page displays summary and navigation correctly
- [x] Check Workshops page links to Events page and no longer lists session details
- [x] Ensure booking email links and costs are accurate on event pages
- [x] Validate metadata and SEO fields on new pages

This reorganisation improves clarity and maintainability by centralising event information and streamlining workshop content.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a2cf5481-fc53-42e4-8f8f-6e817953ed9b