### PR TITLE
Add Songs page with downloadable songbooks and update navigation

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -55,9 +55,9 @@ Ready to join our musical community? [Contact us](/contact) to book your first s
 
 ## Download Our Songbooks
 
-We've created songbooks for our sessions - download them free:
-- [Beginner Songbook (coming soon)](#)
-- [Junior Songbook (coming soon)](#)
+We've created songbooks for our sessions - download them free from our [Songs page](/songs/). Available collections include:
+- Junior Songbook - Perfect for younger players and beginners
+- UGN Songbook - Our main collection for workshops and sessions
 
 ---
 

--- a/pages/learn.md
+++ b/pages/learn.md
@@ -118,7 +118,7 @@ You have your own you know them well, you've played with things before!*
 These basics are just the beginning! To continue your ukulele journey:
 
 - Join our [workshops](/workshops) for hands-on learning
-- Download our songbooks from the [home page](/)
+- Download our [songbooks](/songs/) for practice materials
 - Connect with other players in our community sessions
 - Practice a little each day - consistency is key!
 

--- a/pages/songs.md
+++ b/pages/songs.md
@@ -1,0 +1,46 @@
+---
+header_text: "Songbooks"
+meta_title: "Songbooks | Uke Group North"
+meta_description: "Download our collection of ukulele songbooks with chords and lyrics for your practice and performances."
+subtitle: "Practice materials and song collections"
+header_image: /images/ukelele-2.jpg
+eleventyNavigation:
+  key: Songs
+  order: 7
+permalink: /songs/
+---
+
+## Our Songbook Collection
+
+We've compiled songbooks to help you practice at home and join in during our sessions. These collections feature popular songs with chord charts and lyrics, carefully selected for ukulele players of all levels.
+
+## Available Songbooks
+
+### Junior Songbook
+Perfect for younger players and beginners, this collection features fun, easy-to-play songs that everyone loves. Great for building confidence and learning basic chord progressions.
+
+[Download Junior Songbook (PDF)](/assets/Junior%20Songbook%201.pdf)
+
+### UGN Songbook
+Our main songbook featuring a diverse collection of songs from various genres and decades. This is the primary resource we use in our regular workshops and sessions.
+
+[Download UGN Songbook (PDF)](/assets/UGN%20Songbook%201.1.pdf)
+
+## How to Use These Songbooks
+
+- **Practice at home**: Use these songbooks to practice between sessions
+- **Join our workshops**: Bring your songbook to sessions - we often play songs from these collections
+- **Build your repertoire**: Learn new songs at your own pace
+- **Share the joy**: Play these songs with friends and family
+
+## Tips for Learning New Songs
+
+1. **Start slow**: Don't worry about playing at full speed initially
+2. **Focus on chord changes**: Practice transitioning between chords smoothly
+3. **Sing along**: Combining strumming with singing helps with timing
+4. **Use our workshops**: Get help with tricky songs during our sessions
+5. **Have fun**: Remember, it's about enjoying the music!
+
+## Need Help?
+
+If you're struggling with any songs or chord changes, come along to one of our [workshops](/workshops/) where our friendly instructors can help you master these tunes.

--- a/pages/support.md
+++ b/pages/support.md
@@ -6,7 +6,7 @@ subtitle: "Help us bring music to more communities"
 header_image: /images/ukelele-1.jpg
 eleventyNavigation:
   key: Support
-  order: 7
+  order: 8
 permalink: /support/
 ---
 


### PR DESCRIPTION
## Summary
- Introduces a new Songs page featuring downloadable ukulele songbooks
- Updates Home and Learn pages to link to the new Songs page
- Adjusts navigation order to accommodate the new page

## Changes

### New Songs Page
- Created `/songs/` page with detailed descriptions of two songbooks:
  - Junior Songbook: for younger players and beginners
  - UGN Songbook: main collection used in workshops and sessions
- Provides direct PDF download links for both songbooks
- Includes tips for learning new songs and guidance on using the songbooks effectively

### Updates to Existing Pages
- Home page:
  - Replaced placeholder songbook links with links to the new Songs page
  - Added brief descriptions of available songbook collections
- Learn page:
  - Updated songbook download link to point to the new Songs page
- Support page:
  - Adjusted navigation order to maintain logical flow after adding Songs page

## Test plan
- Verify the Songs page renders correctly with all content and download links
- Check that Home and Learn pages link properly to the Songs page
- Confirm navigation order is updated and the Songs page appears in the menu
- Test PDF downloads for both songbooks to ensure files are accessible

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6bc6b686-2ebe-4839-8efc-70b17df2a22b