### PR TITLE
Add new Sing & Strum sessions and update existing event details

### DIFF
--- a/events/mondays-at-greenmount.md
+++ b/events/mondays-at-greenmount.md
@@ -1,0 +1,38 @@
+---
+title: "Mondays at Greenmount Old School"
+subtitle: "Weekly Sing & Strum Session"
+recurring_date: "Mondays - 10:15am-11:15am"
+event_location: "Greenmount Old School, Brandlesholme Road, BL8 4DS"
+header_text: "Mondays at Greenmount Old School"
+meta_title: "Monday Sessions | Greenmount Old School | Uke Group North"
+meta_description: "Join our weekly Sing & Strum session at Greenmount Old School every Monday 10:15am-11:15am. £6 per person. No instruments required, beginners encouraged."
+---
+
+## Weekly Sing & Strum Session
+
+Join us every Monday morning at Greenmount Old School for our popular Sing & Strum session. No instruments required - beginners are encouraged, and intermediate and advanced players are also welcome!
+
+### Session Details
+
+- **When:** Every Monday, 10:15am - 11:15am
+- **Where:** Greenmount Old School, Brandlesholme Road, BL8 4DS
+- **Cost:** £6 per person
+- **Instrument hire:** +£2 if required
+
+### What to Expect
+
+Our Monday morning sessions are perfect for learning ukulele, playing and singing your favourite songs in a relaxed and welcoming environment. Whether you're a complete beginner or an experienced player, you'll find a warm welcome here. We provide instruments if you don't have your own yet!
+
+### What to Bring
+
+- Your ukulele (or hire one of ours for £2)
+- A music stand if you have one
+- Your enthusiasm!
+
+### Booking
+
+- Email: [ukegroupnorth@gmail.com](mailto:ukegroupnorth@gmail.com)
+- Spaces are limited to ensure quality instruction
+- Block booking discounts available
+
+All abilities welcome - beginners are especially encouraged to join us!

--- a/events/thursdays-at-wyldes.md
+++ b/events/thursdays-at-wyldes.md
@@ -1,0 +1,38 @@
+---
+title: "Thursdays at Wyldes"
+subtitle: "Weekly Sing & Strum Session"
+recurring_date: "Thursdays - 7:30pm-9:30pm"
+event_location: "Wyldes, 4 Bolton St, Bury, BL9 0LQ"
+header_text: "Thursdays at Wyldes"
+meta_title: "Thursday Sessions | Wyldes | Uke Group North"
+meta_description: "Join our weekly Sing & Strum session at Wyldes every Thursday 7:30pm-9:30pm. £6 per person. No instruments required, beginners encouraged."
+---
+
+## Weekly Sing & Strum Session
+
+Join us every Thursday evening at Wyldes for our popular Sing & Strum session. No instruments required - beginners are encouraged, and intermediate and advanced players are also welcome! Learn ukulele, play and sing your favourite songs in a relaxed evening atmosphere.
+
+### Session Details
+
+- **When:** Every Thursday, 7:30pm - 9:30pm
+- **Where:** Wyldes, 4 Bolton St, Bury, BL9 0LQ
+- **Cost:** £6 per person
+- **Instrument hire:** +£2 if required
+
+### What to Expect
+
+Our Thursday evening sessions offer a longer session time (2 hours) perfect for really getting into the music. We play and sing a variety of songs together, suitable for all abilities. Whether you're a complete beginner or an experienced player, you'll find a warm welcome here. We provide instruments if you don't have your own yet!
+
+### What to Bring
+
+- Your ukulele (or hire one of ours for £2)
+- A music stand if you have one
+- Your enthusiasm!
+
+### Booking
+
+- Email: [ukegroupnorth@gmail.com](mailto:ukegroupnorth@gmail.com)
+- Spaces are limited to ensure quality instruction
+- Block booking discounts available
+
+All abilities welcome - beginners are especially encouraged to join us!

--- a/events/tuesdays-at-ramsbottom-library.md
+++ b/events/tuesdays-at-ramsbottom-library.md
@@ -2,15 +2,15 @@
 title: "Tuesdays at Ramsbottom Library"
 subtitle: "Weekly Sing & Strum Session"
 recurring_date: "Tuesdays - 10:30am-12pm"
-event_location: "Ramsbottom Library, Carr St., Ramsbottom"
+event_location: "Ramsbottom Library, Carr St, Ramsbottom, BL0 9AE"
 header_text: "Tuesdays at Ramsbottom Library"
 meta_title: "Tuesday Sessions | Ramsbottom Library | Uke Group North"
-meta_description: "Join our weekly Sing & Strum session at Ramsbottom Library every Tuesday 10:30am-12pm. £8 per person. All abilities welcome."
+meta_description: "Join our weekly Sing & Strum session at Ramsbottom Library every Tuesday 10:30am-12pm. £8 per person. No instruments required, beginners encouraged."
 ---
 
 ## Weekly Sing & Strum Session
 
-Join us every Tuesday morning at Ramsbottom Library for our popular Sing & Strum session. This is our most established regular session, perfect for putting your skills into practice while having fun with a friendly group.
+Join us every Tuesday morning at Ramsbottom Library for our popular Sing & Strum session. No instruments required - beginners are encouraged, and intermediate and advanced players are also welcome! Learn ukulele, play and sing your favourite songs.
 
 ### Session Details
 

--- a/events/tuesdays-at-the-den.md
+++ b/events/tuesdays-at-the-den.md
@@ -2,15 +2,15 @@
 title: "Tuesdays at The Den"
 subtitle: "Weekly Sing & Strum Session"
 recurring_date: "Tuesdays - 5:30pm-7pm"
-event_location: "The Den, Stubbins Vale Rd., Ramsbottom"
+event_location: "The Den, Stubbins, Vale Road, Ramsbottom, BL0 0NT"
 header_text: "Tuesdays at The Den"
 meta_title: "Tuesday Sessions | The Den | Uke Group North"
-meta_description: "Join our weekly Sing & Strum session at The Den every Tuesday 5:30pm-7pm. £6 per person. Perfect for after work or school."
+meta_description: "Join our weekly Sing & Strum session at The Den every Tuesday 5:30pm-7pm. £6 per person. No instruments required, beginners encouraged."
 ---
 
 ## Weekly Sing & Strum Session
 
-Join us every Tuesday evening at The Den for our popular Sing & Strum session. This early evening session is perfect for those who can't make daytime sessions - great for after work or school!
+Join us every Tuesday evening at The Den for our popular Sing & Strum session. No instruments required - beginners are encouraged, and intermediate and advanced players are also welcome! Learn ukulele, play and sing your favourite songs. This early evening session is perfect for those who can't make daytime sessions - great for after work or school!
 
 ### Session Details
 


### PR DESCRIPTION
## Summary
- Adds two new weekly Sing & Strum sessions: Mondays at Greenmount Old School and Thursdays at Wyldes
- Updates existing Tuesday sessions at Ramsbottom Library and The Den with refined location details and enhanced descriptions emphasizing beginner-friendly, no instrument required policy

## Changes

### New Event Files
- **Mondays at Greenmount Old School**: Introduces a Monday morning session from 10:15am to 11:15am with details on cost, instrument hire, and booking
- **Thursdays at Wyldes**: Introduces a Thursday evening session from 7:30pm to 9:30pm with extended playtime and similar booking and cost details

### Updated Event Files
- **Tuesdays at Ramsbottom Library**: Updated location address and meta description to highlight no instrument requirement and beginner encouragement
- **Tuesdays at The Den**: Updated location address and meta description with similar beginner-friendly messaging and no instrument requirement

## Test plan
- Verify new event pages render correctly with all session details
- Confirm updated event pages reflect new location and description changes
- Check booking email links and session times are accurate
- Ensure markdown formatting and metadata are consistent across all event files

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c9df6953-ed7b-4cc0-add0-af0b19e1005a